### PR TITLE
Fix tests to include redis, quiet them down

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,20 +1,21 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/testelasticsearch
+  export TESTDIR=~/tmp/testrediscommander
   mkdir -p $TESTDIR
   export PROJNAME=test-addon-template
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} || true
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
-  ddev start
+  ddev start >/dev/null
+  ddev get drud/ddev-redis >/dev/null
 }
 
 teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  ddev delete -Oy ${PROJNAME}
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
@@ -23,7 +24,7 @@ teardown() {
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart
+  ddev restart >/dev/null
   URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
   curl -s --fail ${URL} | grep "<title>Redis Commander: Home"
 }
@@ -33,6 +34,7 @@ teardown() {
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get drud/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get drud/ddev-redis-commander
-  ddev restart
-  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
+  ddev restart >/dev/null
+  URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
+  curl -s --fail ${URL} | grep "<title>Redis Commander: Home"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -3,12 +3,12 @@ setup() {
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export TESTDIR=~/tmp/testrediscommander
   mkdir -p $TESTDIR
-  export PROJNAME=test-addon-template
+  export PROJNAME=test-redis-commander
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
-  ddev start >/dev/null
+  ddev start -y >/dev/null
   ddev get drud/ddev-redis >/dev/null
 }
 


### PR DESCRIPTION
HEAD Tests started failing recently. I looked and they were never installing redis, which is required. Not sure how they could have worked before. Maybe there was a bug in docker-compose ignoring "requires" that is fixed in recently bumped version?