### PR TITLE
🚚 update to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,15 +49,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'
@@ -67,7 +67,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
+      run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
         docker pull memcached:1.6 >/dev/null
     - name: tmate debugging session

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/drud/ddev-redis-commander/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-redis-commander/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-redis-commander/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-redis-commander/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## Redis Commander
 
@@ -6,11 +6,11 @@ This uses Redis Commander to provide a web interface to a redis service on DDEV.
 
 ## Requirements
 
-The redis service must be available, use `ddev get drud/ddev-redis`.
+The redis service must be available, use `ddev get ddev/ddev-redis`.
 
 ## Installation
 
-`ddev get drud/ddev-redis && ddev get drud/ddev-redis-commander && ddev restart`
+`ddev get ddev/ddev-redis && ddev get ddev/ddev-redis-commander && ddev restart`
 
 Then `ddev describe` will show you how to access the service at `https://<project>.ddev.site:1359`.
 
@@ -19,8 +19,6 @@ Then `ddev describe` will show you how to access the service at `https://<projec
 * [Multiplatform Images](https://github.com/joeferner/redis-commander/pkgs/container/redis-commander)
 * GitHub repo: [joeferner/redis-commander](https://github.com/joeferner/redis-commander)
 
-**Originally Contributed by [@Graloth](https://github.com/Graloth) in [ddev-contrib](https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/redis-commander)**
+**Originally Contributed by [@Graloth](https://github.com/Graloth) in [ddev-contrib](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/redis-commander)**
 
-**Maintained by [@rfay](https://github.com/rfay) and looking for a maintainer that actually uses this, see [#1](https://github.com/drud/ddev-redis-commander/issues/1).**
-
-
+**Maintained by [@rfay](https://github.com/rfay) and looking for a maintainer that actually uses this, see [#1](https://github.com/ddev/ddev-redis-commander/issues/1).**

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -9,7 +9,7 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev start -y >/dev/null
-  ddev get drud/ddev-redis >/dev/null
+  ddev get ddev/ddev-redis >/dev/null
 }
 
 teardown() {
@@ -32,8 +32,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-redis-commander
+  echo "# ddev get ddev/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-redis-commander
   ddev restart >/dev/null
   URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
   curl -s --fail ${URL} | grep "<title>Redis Commander: Home"


### PR DESCRIPTION
This PR updates docs and tests for the move to `ddev` domain.