### PR TITLE
docs(changelog): Add CHANGELOG and SemVer public API description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Create Release
+# example: gh workflow run release.yml -f tag_name=v1.1.4 -f draft=true
+on:
+  workflow_dispatch:
+    branches:
+      - main
+    inputs:
+      tag_name:
+        type: string
+        required: true
+      draft:
+        type: boolean
+        description: Draft release
+        default: false
+      prerelease:
+        type: boolean
+        description: Prerelease
+        default: false
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check naming convention
+        run: |
+          VERIF=$(echo ${{ github.event.inputs.tag_name }} | grep -E "^v([0-9]{1,}\.)([0-9]{1,}\.)([0-9]{1,})(-(alpha|beta)\.[0-9]{1,})?$")
+          if [ ! ${VERIF} ]
+          then
+            echo "Tag name '${{ github.event.inputs.tag_name }}' does not comply with naming convention vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Set version number without v
+        run: |
+          echo "VERSION_NUMBER=$(echo ${{ github.event.inputs.tag_name }} | sed 's/v//g' )" >> $GITHUB_ENV
+
+      - name: Clone sources
+        uses: actions/checkout@v3
+
+      - name: Check version ${{ env.VERSION_NUMBER }} consistency in files
+        # Check CHANGELOG.md
+        run: |
+          
+          # Check top ## [VERSION_NUMBER](GITHUB_URL/releases/tag/vVERSION_NUMBER) - yyyy-mm-dd in CHANGELOG.md
+          CURRENT_DATE=$(date +'%Y-%m-%d')
+          echo $CURRENT_DATE
+          CHANGELOG_VERSION=$(grep -o -E "## \[(.*)\].* - $CURRENT_DATE"  CHANGELOG.md | head -1 | sed 's/ //g')
+          echo $CHANGELOG_VERSION
+          if [[ $CHANGELOG_VERSION == "##[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/v${{ env.VERSION_NUMBER }})-$CURRENT_DATE" ]]
+          then
+              echo "CHANGELOG VERSION OK"
+          else
+              echo "CHANGELOG VERSION KO"
+              exit 1
+          fi
+          
+          # Check top [_Compare with previous release_](GITHUB_URL/compare/vLAST_TAG...vVERSION_NUMBER) in CHANGELOG.md
+          COMPARISON=$(grep -oP "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/\K(.*)$" CHANGELOG.md | head -1)
+          LAST_TAG=$(curl -Ls -o /dev/null -w %{url_effective} $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/latest | grep -oP "\/tag\/\K(.*)$")
+          if [[ $COMPARISON == "$LAST_TAG...v${{ env.VERSION_NUMBER }})" ]]
+          then
+            echo "VERSION COMPARISON OK"
+          else
+            echo "VERSION COMPARISON KO"
+            echo $COMPARISON
+            echo "$LAST_TAG...v${{ env.VERSION_NUMBER }})"
+            exit 1
+          fi
+
+      - name: Create Tag ${{ github.event.inputs.tag_name }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ github.event.inputs.tag_name }}",
+              sha: context.sha
+            })
+
+      - name: Prepare release notes
+        run: |
+          # Retrieve release body and remove ---
+          VERSION_RELEASE_NOTES=$(awk -v ver="[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/v${{ env.VERSION_NUMBER }})" '/^## / { if (p) { exit }; if ($2 == ver) { p=1; next} } p && NF' CHANGELOG.md | sed ':a;N;$!ba;s/\n---/ /g')
+          echo "$VERSION_RELEASE_NOTES" >> CHANGELOG.txt
+
+      - name: Create release ${{ env.VERSION_NUMBER }}
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: CHANGELOG.txt
+          name: ${{ env.VERSION_NUMBER }}
+          tag_name: ${{ github.event.inputs.tag_name }}
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: ${{ github.event.inputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
             exit 1
           fi
 
-      - name: Set version number without v
+      - name: Set version number with v
         run: |
-          echo "VERSION_NUMBER=$(echo ${{ github.event.inputs.tag_name }} | sed 's/v//g' )" >> $GITHUB_ENV
+          echo "VERSION_NUMBER=$(echo ${{ github.event.inputs.tag_name }})" >> $GITHUB_ENV
 
       - name: Clone sources
         uses: actions/checkout@v3
@@ -45,12 +45,12 @@ jobs:
         # Check CHANGELOG.md
         run: |
           
-          # Check top ## [VERSION_NUMBER](GITHUB_URL/releases/tag/vVERSION_NUMBER) - yyyy-mm-dd in CHANGELOG.md
+          # Check top ## [VERSION_NUMBER](GITHUB_URL/releases/tag/VERSION_NUMBER) - yyyy-mm-dd in CHANGELOG.md
           CURRENT_DATE=$(date +'%Y-%m-%d')
           echo $CURRENT_DATE
           CHANGELOG_VERSION=$(grep -o -E "## \[(.*)\].* - $CURRENT_DATE"  CHANGELOG.md | head -1 | sed 's/ //g')
           echo $CHANGELOG_VERSION
-          if [[ $CHANGELOG_VERSION == "##[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/v${{ env.VERSION_NUMBER }})-$CURRENT_DATE" ]]
+          if [[ $CHANGELOG_VERSION == "##[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/${{ env.VERSION_NUMBER }})-$CURRENT_DATE" ]]
           then
               echo "CHANGELOG VERSION OK"
           else
@@ -58,16 +58,16 @@ jobs:
               exit 1
           fi
           
-          # Check top [_Compare with previous release_](GITHUB_URL/compare/vLAST_TAG...vVERSION_NUMBER) in CHANGELOG.md
+          # Check top [_Compare with previous release_](GITHUB_URL/compare/LAST_TAG...VERSION_NUMBER) in CHANGELOG.md
           COMPARISON=$(grep -oP "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/\K(.*)$" CHANGELOG.md | head -1)
           LAST_TAG=$(curl -Ls -o /dev/null -w %{url_effective} $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/latest | grep -oP "\/tag\/\K(.*)$")
-          if [[ $COMPARISON == "$LAST_TAG...v${{ env.VERSION_NUMBER }})" ]]
+          if [[ $COMPARISON == "$LAST_TAG...${{ env.VERSION_NUMBER }})" ]]
           then
             echo "VERSION COMPARISON OK"
           else
             echo "VERSION COMPARISON KO"
             echo $COMPARISON
-            echo "$LAST_TAG...v${{ env.VERSION_NUMBER }})"
+            echo "$LAST_TAG...${{ env.VERSION_NUMBER }})"
             exit 1
           fi
 
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare release notes
         run: |
           # Retrieve release body and remove ---
-          VERSION_RELEASE_NOTES=$(awk -v ver="[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/v${{ env.VERSION_NUMBER }})" '/^## / { if (p) { exit }; if ($2 == ver) { p=1; next} } p && NF' CHANGELOG.md | sed ':a;N;$!ba;s/\n---/ /g')
+          VERSION_RELEASE_NOTES=$(awk -v ver="[${{ env.VERSION_NUMBER }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/${{ env.VERSION_NUMBER }})" '/^## / { if (p) { exit }; if ($2 == ver) { p=1; next} } p && NF' CHANGELOG.md | sed ':a;N;$!ba;s/\n---/ /g')
           echo "$VERSION_RELEASE_NOTES" >> CHANGELOG.txt
 
       - name: Create release ${{ env.VERSION_NUMBER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## SemVer public API
+
+The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) for this project is defined by the files `docker-compose.redis-commander.yaml` and `install.yaml`.
+
+---
+
+## [1.0.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v1.0.0) - 2023-03-??
+[_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.2...v1.0.0)
+
+
+### Changed
+
+- Disable healthcheck in `docker-compose.redis-commander.yaml`
+
+
+---
+
+## [0.1.2](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.2) - 2023-02-03
+[_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.1...v0.1.2)
+
+
+### Changed
+
+- Remove docker-compose version in `docker-compose.redis-commander.yaml`
+- Move from `drud` to `ddev` org
+
+---
+
+
+## [0.1.1](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.1) - 2022-06-17
+[_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.0...v0.1.1)
+
+
+### Changed
+
+- All files must contain #ddev-generated
+
+---
+
+## [0.1.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.0) - 2022-03-22
+[_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/0.0.1...v0.1.0)
+
+### Added
+
+- Add dependency on `redis` container
+- Add healthcheck timeout
+
+### Changed
+
+- Use multi-arch images
+
+---
+
+## [0.0.1](https://github.com/ddev/ddev-redis-commander/releases/tag/0.0.1) - 2022-03-22
+
+### Added
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) for this proje
 
 ---
 
-## [1.0.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v1.0.0) - 2023-03-??
+## [v1.0.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v1.0.0) - 2023-03-08
 [_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.2...v1.0.0)
 
 
@@ -22,7 +22,7 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) for this proje
 
 ---
 
-## [0.1.2](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.2) - 2023-02-03
+## [v0.1.2](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.2) - 2023-02-03
 [_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.1...v0.1.2)
 
 
@@ -34,7 +34,7 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) for this proje
 ---
 
 
-## [0.1.1](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.1) - 2022-06-17
+## [v0.1.1](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.1) - 2022-06-17
 [_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/v0.1.0...v0.1.1)
 
 
@@ -44,7 +44,7 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) for this proje
 
 ---
 
-## [0.1.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.0) - 2022-03-22
+## [v0.1.0](https://github.com/ddev/ddev-redis-commander/releases/tag/v0.1.0) - 2022-03-22
 [_Compare with previous release_](https://github.com/ddev/ddev-redis-commander/compare/0.0.1...v0.1.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Then `ddev describe` will show you how to access the service at `https://<projec
 
 **Originally Contributed by [@Graloth](https://github.com/Graloth) in [ddev-contrib](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/redis-commander)**
 
-**Maintained by [@rfay](https://github.com/rfay) and looking for a maintainer that actually uses this, see [#1](https://github.com/ddev/ddev-redis-commander/issues/1).**
+**Maintained by [@julienloizelet](https://github.com/julienloizelet)**


### PR DESCRIPTION
Hi,
In order to create my first release here (1.0.0), I would like to add a CHANGELOG to inform users that we are using the SemVer specification.

I also add a "release" GitHub action that has 2 purposes:

1. Check consistency between the release tag and the source code
2. Force releaser to respect some format for the CHANGELOG file

Please let me know what you think.

Thanks
