### PR TITLE
Add dependency on redis add-on

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,5 +1,8 @@
 name: redis-commander
 
+dependencies:
+- redis
+
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
 - docker-compose.redis-commander.yaml


### PR DESCRIPTION

## The Issue

In v1.22.0 we can declare dependencies; add redis


## How This PR Solves The Issue

## Manual Testing Instructions

Make sure it works in v1.22.0
Make sure it doesn't break v1.21.6

\