### PR TITLE
 [BUGFIX] Disable restart "always", fixes #14

### DIFF
--- a/docker-compose.redis-commander.yaml
+++ b/docker-compose.redis-commander.yaml
@@ -6,7 +6,6 @@ services:
     container_name: ddev-${DDEV_SITENAME}-redis-commander
     hostname: ${DDEV_SITENAME}-redis-commander
     image: ghcr.io/joeferner/redis-commander:latest
-    restart: always
     expose:
       - 1358
     labels:


### PR DESCRIPTION
The service MUST NOT always restart.
Without that change the service will be restarted after docker and/or host restart.

Fixes: #14