### PR TITLE
feat(*): Add redis-commander command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Create Release
-# example: gh workflow run release.yml -f tag_name=v1.1.4 -f draft=true
+# example: gh workflow run release.yml -f tag_name=v1.1.4
 on:
   workflow_dispatch:
     branches:
@@ -8,14 +8,6 @@ on:
       tag_name:
         type: string
         required: true
-      draft:
-        type: boolean
-        description: Draft release
-        default: false
-      prerelease:
-        type: boolean
-        description: Prerelease
-        default: false
 
 jobs:
   create-release:
@@ -39,7 +31,7 @@ jobs:
           echo "VERSION_NUMBER=$(echo ${{ github.event.inputs.tag_name }})" >> $GITHUB_ENV
 
       - name: Clone sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check version ${{ env.VERSION_NUMBER }} consistency in files
         # Check CHANGELOG.md
@@ -72,7 +64,7 @@ jobs:
           fi
 
       - name: Create Tag ${{ github.event.inputs.tag_name }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
           script: |
@@ -90,10 +82,10 @@ jobs:
           echo "$VERSION_RELEASE_NOTES" >> CHANGELOG.txt
 
       - name: Create release ${{ env.VERSION_NUMBER }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body_path: CHANGELOG.txt
           name: ${{ env.VERSION_NUMBER }}
           tag_name: ${{ github.event.inputs.tag_name }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: ${{ github.event.inputs.prerelease }}
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -6,13 +6,40 @@ This uses Redis Commander to provide a web interface to a redis service on DDEV.
 
 ## Requirements
 
-The redis service must be available, use `ddev get ddev/ddev-redis`.
+Before installing this add-on, the Redis service must be available, and you have to use one of the following add-ons:
+
+- [`ddev/ddev-redis` (Redis 6)](https://github.com/ddev/ddev-redis)
+- [`ddev/ddev-redis-7` (Redis 7)](https://github.com/ddev/ddev-redis-7)
+
+To install one of them, run `ddev add-on get ddev/ddev-redis` or `ddev add-on get ddev/ddev-redis-7`
 
 ## Installation
 
-`ddev get ddev/ddev-redis && ddev get ddev/ddev-redis-commander && ddev restart`
+`ddev add-on get ddev/ddev-redis-commander && ddev restart`
 
-Then `ddev describe` will show you how to access the service at `https://<project>.ddev.site:1359`.
+## Usage
+
+Access the Redis Commander web interface by running `ddev redis-commander`.
+
+### Redis 7 password
+
+At the time of writing, Redis 7 requires a password to connect to it.
+
+In order to connect to Redis 7, you have to set the `REDIS_PASSWORD` environment variable in the `redis-commander` 
+service. 
+
+One way of doing this is to create a `docker-compose.redis_password.yaml` file with the following content:
+
+```yaml
+services:
+    redis-commander:
+        environment:
+            - REDIS_PASSWORD=redis
+```
+You may have to adjust the password according to your Redis 7 configuration (`redis` is the default one).
+
+Then, run `ddev restart` to apply the changes.
+
 
 ## Links
 

--- a/commands/host/redis-commander
+++ b/commands/host/redis-commander
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Launch a browser with Redis Commander
+## Usage: redis-commander
+## Example: "ddev redis-commander"
+
+# Determine whether to use HTTP or HTTPS based on environment
+PROTOCOL="HTTP"
+if [ "${DDEV_PRIMARY_URL%://*}" != "http" ] && [ -z "${GITPOD_WORKSPACE_ID:-}" ] && [ "${CODESPACES:-}" != "true" ]; then
+    PROTOCOL="HTTPS"
+fi
+
+# Fetch the appropriate port within the redis-commander container
+DDEV_REDIS_COMMANDER_PORT=$(ddev exec -s redis-commander sh -c "printenv | grep -w ${PROTOCOL}_EXPOSE | cut -d '=' -f 2 | cut -d ':' -f 1")
+
+if [ -z "$DDEV_REDIS_COMMANDER_PORT" ]; then
+    echo "Error: Could not retrieve Redis Commander port."
+    exit 1
+fi
+
+ddev launch :"$DDEV_REDIS_COMMANDER_PORT"
+

--- a/docker-compose.redis-commander_norouter.yaml
+++ b/docker-compose.redis-commander_norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 1358 to 1358
+services: {}

--- a/install.yaml
+++ b/install.yaml
@@ -6,3 +6,23 @@ dependencies:
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
 - docker-compose.redis-commander.yaml
+- docker-compose.redis-commander_norouter.yaml
+- commands/host/redis-commander
+
+
+pre_install_actions:
+  # Ensure we're on DDEV 1.23+. It's required for the `redis-commander` command (launch by port).
+  - |
+    #ddev-nodisplay
+    #ddev-description:Checking DDEV version
+    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to enable launching." && false)
+
+post_install_actions:
+  - |
+    #ddev-description:If router disabled, directly expose port
+    #
+    if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
+      printf "#ddev-generated\nservices:\n  redis-commander:\n    ports:\n      - 1358:1358\n" > docker-compose.redis-commander_norouter.yaml
+    fi
+  - |
+    echo "You can now use 'ddev redis-commander' to launch Redis Commander UI"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,14 +1,19 @@
 setup() {
   set -eu -o pipefail
+  brew_prefix=$(brew --prefix)
+  load "${brew_prefix}/lib/bats-support/load.bash"
+  load "${brew_prefix}/lib/bats-assert/load.bash"
+
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export TESTDIR=~/tmp/testrediscommander
   mkdir -p $TESTDIR
   export PROJNAME=test-redis-commander
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev start -y >/dev/null
+  # Redis add-on is required for Redis Commander
   ddev get ddev/ddev-redis >/dev/null
 }
 
@@ -19,22 +24,34 @@ teardown() {
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
+health_checks() {
+  set +u # bats-assert has unset variables so turn off unset check
+  # ddev restart is required because we have done `ddev get` on a new service
+  run ddev restart
+  assert_success
+  # Make sure we can hit the HTTP port successfully
+  URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
+  curl -s --fail "${URL}" | grep "<title>Redis Commander: Home"
+  # Make sure `ddev redis-commander` works
+  DDEV_DEBUG=true run ddev redis-commander
+  assert_success
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:1359"
+}
+
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart >/dev/null
-  URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
-  curl -s --fail ${URL} | grep "<title>Redis Commander: Home"
+  health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get ddev/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ddev/ddev-redis-commander
   ddev restart >/dev/null
-  URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.\"redis-commander\".http_url)
-  curl -s --fail ${URL} | grep "<title>Redis Commander: Home"
+  health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,7 +14,7 @@ setup() {
   ddev config --project-name=${PROJNAME}
   ddev start -y >/dev/null
   # Redis add-on is required for Redis Commander
-  ddev get ddev/ddev-redis >/dev/null
+  ddev add-on get ddev/ddev-redis >/dev/null
 }
 
 teardown() {
@@ -41,8 +41,8 @@ health_checks() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   health_checks
 }
 
@@ -50,8 +50,8 @@ health_checks() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-redis-commander
+  echo "# ddev add-on get ddev/ddev-redis-commander with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ddev/ddev-redis-commander
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
## The Issue

This PR follows this comment: https://github.com/ddev/ddev-redis-commander/issues/17#issuecomment-2430530272

I've also updated the README with up to date information.

## How This PR Solves The Issue

It adds a `ddev redis-commander` command to launch the Web interface easily.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

I've added a test for the command

## Related Issue Link(s)

- https://github.com/ddev/ddev-redis-commander/issues/17

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

