### PR TITLE
feat(*): support for Redis password

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -17,4 +17,21 @@ post_install_actions:
       printf "#ddev-generated\nservices:\n  redis-commander:\n    ports:\n      - 1358:1358\n" > docker-compose.redis-commander_norouter.yaml
     fi
   - |
+    #ddev-description:If Redis is optimized, set a password
+    if [ $(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null) = "true" ]; then
+      printf "#ddev-generated\nservices:\n  redis-commander:\n    environment:\n      - REDIS_PASSWORD=redis\n" > docker-compose.redis-commander_password.yaml
+    fi
+  - |
     echo "You can now use 'ddev redis-commander' to launch Redis Commander UI"
+
+removal_actions:
+  - |
+    #ddev-description:Remove docker-compose.redis-commander_password.yaml file
+    file=docker-compose.redis-commander_password.yaml
+    if [ -f "${file}" ]; then
+      if grep -q '#ddev-generated' "${file}"; then
+        rm -f "${file}"
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/${file}' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi


### PR DESCRIPTION
## The Issue

README.md explains how to set `REDIS_PASSWORD` for `redis-commander`, and it can be automated.

I recently updated [ddev-redis](https://github.com/ddev/ddev-redis) and now it supports both auth/no auth options.

## How This PR Solves The Issue

- Adds `.ddev/docker-compose.redis-commander_password.yaml` file.
- Updates tests.
- README.md will be updated in another PR.

## Manual Testing Instructions

```bash
ddev dotenv set .ddev/.env.redis --redis-optimized=true
ddev add-on get ddev/ddev-redis
ddev add-on get https://github.com/ddev/ddev-redis-commander/tarball/20250428_stasadev_redis_password
cat .ddev/docker-compose.redis-commander_password.yaml
ddev restart
ddev redis-commander
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
