### PR TITLE
feat(*): add REDIS_COMMANDER_DOCKER_IMAGE, use `#!/usr/bin/env bash`

### DIFF
--- a/commands/host/redis-commander
+++ b/commands/host/redis-commander
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with Redis Commander
@@ -20,4 +20,3 @@ if [ -z "$DDEV_REDIS_COMMANDER_PORT" ]; then
 fi
 
 ddev launch :"$DDEV_REDIS_COMMANDER_PORT"
-

--- a/docker-compose.redis-commander.yaml
+++ b/docker-compose.redis-commander.yaml
@@ -5,21 +5,22 @@ services:
   redis-commander:
     container_name: ddev-${DDEV_SITENAME}-redis-commander
     hostname: ${DDEV_SITENAME}-redis-commander
-    image: ghcr.io/joeferner/redis-commander:latest
+    image: ${REDIS_COMMANDER_DOCKER_IMAGE:-ghcr.io/joeferner/redis-commander:latest}
     expose:
       - 1358
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=1358
+      - HTTP_EXPOSE=1358:1358
       - HTTPS_EXPOSE=1359:1358
       - REDIS_PORT=6379
       - REDIS_HOST=redis
       - PORT=1358
     volumes:
       - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
     depends_on:
       - redis
     healthcheck:


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-template` has some changes.

## How This PR Solves The Issue

- Adds override for the image with `REDIS_COMMANDER_DOCKER_IMAGE`.
- Uses `#!/usr/bin/env bash` instead of `#!/bin/bash` (for NixOS)
- Adds `ddev-global-cache` volume.
- README.md will be updated in another PR.

## Manual Testing Instructions

```bash
ddev dotenv set .ddev/.env.redis-commander --redis-commander-docker-image=ghcr.io/joeferner/redis-commander:0.9
ddev add-on get https://github.com/ddev/ddev-redis-commander/tarball/20250428_stasadev_cmd
ddev restart
# see Docker pulling for "0.9" tag
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
