### PR TITLE
fix: add quotes in if statement, give qualified path to redis

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: redis-commander
 
 dependencies:
-  - redis
+  - ddev/ddev-redis
 
 project_files:
   - docker-compose.redis-commander.yaml
@@ -18,7 +18,7 @@ post_install_actions:
     fi
   - |
     #ddev-description:If Redis is optimized, set a password
-    if [ $(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null) = "true" ]; then
+    if [ "$(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null)" = "true" ]; then
       printf "#ddev-generated\nservices:\n  redis-commander:\n    environment:\n      - REDIS_PASSWORD=redis\n" > docker-compose.redis-commander_password.yaml
     fi
   - |


### PR DESCRIPTION
## The Issue

* If there is no output from `ddev dotenv get .ddev/.env.redis --redis-optimized` the install.yaml fails with 
    ```
    👍 If Redis is optimized, set a password
    bash: line 3: [: =: unary operator expected
    ```
* The `dependencies` section (rarely used) shows `redis`, which won't work when we try to download dependencies recursively, because there's no statement of where to get it from. Change to `ddev/ddev-redis`

## How This PR Solves The Issue

Fix these two minor issues

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/rfay/ddev-redis-commander/tarball/20250903_rfay_fix_quotes
ddev restart
```

* Verify behavior when redis is already present
* Verify behavior when ddev/ddev-redis is not already present
* Verify behavior when there is no `.ddev/.env.redis` already existing.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
